### PR TITLE
add color key for bar chart

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>org.pabuff</groupId>
     <artifactId>util</artifactId>
-    <version>2.33.3</version>
+    <version>2.33.4</version>
 
     <distributionManagement>
         <repository>

--- a/src/main/java/org/pabuff/utils/ExcelUtil.java
+++ b/src/main/java/org/pabuff/utils/ExcelUtil.java
@@ -2,9 +2,7 @@ package org.pabuff.utils;
 
 import org.apache.poi.ss.usermodel.*;
 import org.apache.poi.ss.util.CellRangeAddress;
-import org.apache.poi.xddf.usermodel.XDDFFillProperties;
-import org.apache.poi.xddf.usermodel.XDDFLineProperties;
-import org.apache.poi.xddf.usermodel.XDDFShapeProperties;
+import org.apache.poi.xddf.usermodel.*;
 import org.apache.poi.xddf.usermodel.chart.*;
 import org.apache.poi.xssf.usermodel.*;
 
@@ -868,6 +866,14 @@ public class ExcelUtil {
                     barChartData.setVaryColors(varyColors);
                 }else if(dataMap.get("vary_colors") instanceof Boolean varyColors){
                     barChartData.setVaryColors(varyColors);
+                }
+
+                if (seriesData.get("bar_color") instanceof XDDFColor barColor) {
+                    XDDFSolidFillProperties fillProperties = new XDDFSolidFillProperties(barColor);
+                    barSeries.setFillProperties(fillProperties);
+                } else if (dataMap.get("bar_color") instanceof XDDFColor barColor) {
+                    XDDFSolidFillProperties fillProperties = new XDDFSolidFillProperties(barColor);
+                    barSeries.setFillProperties(fillProperties);
                 }
 
                 if(seriesData.get("error_bars") instanceof XDDFErrorBars errorBars){


### PR DESCRIPTION
This pull request includes several updates to the `pom.xml` file and the `ExcelUtil.java` class to enhance functionality and maintain dependencies. The most important changes are:

Dependency updates:

* [`pom.xml`](diffhunk://#diff-9c5fb3d1b7e3b0f54bc5c4182965c4fe1f9023d449017cece3005d3f90e8e4d8L9-R9): Updated the version of the `util` artifact from `2.33.3` to `2.33.4` to ensure compatibility with the latest features and bug fixes.

Code simplification and enhancements in `ExcelUtil.java`:

* [`src/main/java/org/pabuff/utils/ExcelUtil.java`](diffhunk://#diff-88867b2969613b22fe04bbc0dbb031c3ea51202cc953f5b649376736b659ef18L5-R5): Simplified import statements by using wildcard imports for `org.apache.poi.xddf.usermodel` package.
* [`public static void addChart`](diffhunk://#diff-88867b2969613b22fe04bbc0dbb031c3ea51202cc953f5b649376736b659ef18R871-R878): Added logic to handle the `bar_color` property for bar charts, allowing for customization of bar colors using `XDDFColor` and `XDDFSolidFillProperties`. This enhancement improves the visual customization of generated charts.