### PR TITLE
Excel Pdf Util update

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>org.pabuff</groupId>
     <artifactId>util</artifactId>
-    <version>2.39.3</version>
+    <version>2.39.4</version>
 
     <distributionManagement>
         <repository>

--- a/src/main/java/org/pabuff/utils/ExcelUtil.java
+++ b/src/main/java/org/pabuff/utils/ExcelUtil.java
@@ -1478,21 +1478,21 @@ public class ExcelUtil {
 
     private static void setCellValue(Cell cell, Object value) {
 
-        DecimalFormat decimalFormat = new DecimalFormat("#,##0.##");
+//        DecimalFormat decimalFormat = new DecimalFormat("#,##0.##");
         DecimalFormat decimalFormat2 = new DecimalFormat("#,##0.00");
 
         switch (value) {
             case null -> cell.setBlank();
-            case BigDecimal bd -> cell.setCellValue(decimalFormat.format(bd));
-            case Integer i -> cell.setCellValue(decimalFormat.format(i));
-            case Long l -> cell.setCellValue(decimalFormat.format(l));
+            case BigDecimal bd -> cell.setCellValue(decimalFormat2.format(bd));
+            case Integer i -> cell.setCellValue(decimalFormat2.format(i));
+            case Long l -> cell.setCellValue(decimalFormat2.format(l));
             case Double d -> cell.setCellValue(decimalFormat2.format(d));
             case Float f -> cell.setCellValue(decimalFormat2.format(f));
             case String str -> {
                 String trimmed = str.trim();
                 try {
                     BigDecimal bd = new BigDecimal(trimmed.replace(",", ""));
-                    cell.setCellValue(decimalFormat.format(bd));
+                    cell.setCellValue(decimalFormat2.format(bd));
                 } catch (NumberFormatException e) {
                     cell.setCellValue(str);
                 }

--- a/src/main/java/org/pabuff/utils/PdfUtil.java
+++ b/src/main/java/org/pabuff/utils/PdfUtil.java
@@ -459,13 +459,13 @@ public class PdfUtil {
             return "";
         }
 
-        DecimalFormat decimalFormat = new DecimalFormat("#,##0.##");
+//        DecimalFormat decimalFormat = new DecimalFormat("#,##0.##");
         DecimalFormat decimalFormat2 = new DecimalFormat("#,##0.00");
 
         return switch (value) {
-            case BigDecimal bd -> decimalFormat.format(bd);
-            case Integer i -> decimalFormat.format(i);
-            case Long l -> decimalFormat.format(l);
+            case BigDecimal bd -> decimalFormat2.format(bd);
+            case Integer i -> decimalFormat2.format(i);
+            case Long l -> decimalFormat2.format(l);
             case Double d -> decimalFormat2.format(d);
             case Float f -> decimalFormat2.format(f);
             case LocalDateTime ldt -> ldt.toString();
@@ -473,7 +473,7 @@ public class PdfUtil {
                 String trimmed = str.trim();
                 try {
                     BigDecimal bd = new BigDecimal(trimmed.replace(",", ""));
-                    yield decimalFormat.format(bd);
+                    yield decimalFormat2.format(bd);
                 } catch (NumberFormatException e) {
                     yield str;
                 }


### PR DESCRIPTION
This pull request updates number formatting in both Excel and PDF utility classes to ensure all numeric values are consistently formatted with two decimal places. Additionally, it bumps the project version in `pom.xml`.

**Number formatting changes:**

* [`src/main/java/org/pabuff/utils/ExcelUtil.java`](diffhunk://#diff-88867b2969613b22fe04bbc0dbb031c3ea51202cc953f5b649376736b659ef18L1481-R1495): Updated the `setCellValue` method to use a `DecimalFormat` pattern of `#,##0.00` for all numeric types, ensuring two decimal places are always displayed.
* [`src/main/java/org/pabuff/utils/PdfUtil.java`](diffhunk://#diff-29d305b378c6a05dfe9a272fd597105096d4566c0d0241df663eac50903a5742L462-R476): Updated the `formatValue` method to use the same two-decimal format for all numeric values, aligning PDF output with Excel output.

**Project configuration:**

* [`pom.xml`](diffhunk://#diff-9c5fb3d1b7e3b0f54bc5c4182965c4fe1f9023d449017cece3005d3f90e8e4d8L9-R9): Bumped the project version from `2.39.3` to `2.39.4`.